### PR TITLE
fix the URL in the library.properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Chris Johnson <chrisjohnsonmail@gmail.com>
 sentence=A port of ArduinoSTL Arduino library.
 paragraph=This library includes important C++ functions, including cout and cin, printf and scanf. It also includes STL containers like vector and algorithm. 
 category=Other
-url=https://https://github.com/ciband/avr_stl
+url=https://github.com/ciband/avr_stl
 architectures=avr,samd
 includes=avr_stl.h


### PR DESCRIPTION
the current "More info" link in the Arduino IDE's library manager is broken because this URL is wrong.