### PR TITLE
Fix build for c++17, exception specifications are not allowed anymore.

### DIFF
--- a/src/new
+++ b/src/new
@@ -36,14 +36,21 @@ namespace std{
 	_UCXXEXPORT new_handler set_new_handler(new_handler new_p) throw();
 }
 
-
-_UCXXEXPORT void* operator new(std::size_t numBytes) throw(std::bad_alloc);
+#if (__cplusplus < 201703L)
+    _UCXXEXPORT void* operator new(std::size_t numBytes) throw(std::bad_alloc);
+#else
+    _UCXXEXPORT void* operator new(std::size_t numBytes) noexcept(false);
+#endif
 _UCXXEXPORT void operator delete(void* ptr) throw();
 #if __cpp_sized_deallocation
 _UCXXEXPORT void operator delete(void* ptr, std::size_t) throw();
 #endif
 
-_UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc);
+#if (__cplusplus < 201703L)
+    _UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc);
+#else
+    _UCXXEXPORT void* operator new[](std::size_t numBytes) noexcept(false);
+#endif
 _UCXXEXPORT void operator delete[](void * ptr) throw();
 #if __cpp_sized_deallocation
 _UCXXEXPORT void operator delete[](void * ptr, std::size_t) throw();


### PR DESCRIPTION
Exception specifications are deprecated since c++11, but they are still allowed in c++14.
c++17 doesn't allow them anymore, I fixed it by checking the c++ version used for build.