### PR TITLE
Add Arduino.h include for ArduinoCore-API based cores

### DIFF
--- a/src/ArduinoSTL.h
+++ b/src/ArduinoSTL.h
@@ -9,6 +9,7 @@
 #ifndef ARDUINOSTL_M_H
 #define ARDUINOSTL_M_H
 
+#include "Arduino.h"
 #include <serstream>
 
 // Create cout and cin.. there doesn't seem to be a way


### PR DESCRIPTION
https://github.com/arduino/ArduinoCore-megaavr can use this library but compilation fails on `::Stream` since all APIs are in `arduino::` namespace now.
The easiest way to keep compatibility is including Arduino.h at the top of the offending files.

@ubidefeo @aentinger